### PR TITLE
Fix missing import of chipwhisperer utils.util

### DIFF
--- a/cwtvla/ktp.py
+++ b/cwtvla/ktp.py
@@ -173,6 +173,7 @@ class FixedVRandomKey:
 
         return key, text
 
+
 class SemiFixedVRandomText:
     """ Key text pairs for SemiFixedVRandomText.
 

--- a/cwtvla/ktp.py
+++ b/cwtvla/ktp.py
@@ -58,6 +58,7 @@ def verify_AES(plaintext, key, ciphertext):
     calc_ciphertext = bytearray(cipher.cipher_block(list(plaintext)))
     return (ciphertext == calc_ciphertext)
 
+
 class FixedVRandomText:
     """ Key text pairs for FixedVRandomText TVLA
 
@@ -172,7 +173,6 @@ class FixedVRandomKey:
         self._I_0_rand = bytearray(self._cipher.cipher_block(list(text)))
 
         return key, text
-
 
 class SemiFixedVRandomText:
     """ Key text pairs for SemiFixedVRandomText.

--- a/cwtvla/ktp.py
+++ b/cwtvla/ktp.py
@@ -3,6 +3,7 @@ from .aes_cipher import AESCipher
 from .key_schedule import key_schedule_rounds
 import numpy as np
 import random
+from chipwhisperer.common.utils import util
 
 def hexstr2list(data):
     """Convert a string with hex numbers into a list of numbers"""
@@ -56,7 +57,6 @@ def verify_AES(plaintext, key, ciphertext):
     cipher = AESCipher(key_exp)
     calc_ciphertext = bytearray(cipher.cipher_block(list(plaintext)))
     return (ciphertext == calc_ciphertext)
-
 
 class FixedVRandomText:
     """ Key text pairs for FixedVRandomText TVLA


### PR DESCRIPTION
Tests rely on `util.hexStrToByteArray` from the chipwhisperer source.  It seems reasonable to depend on this, so I have just imported it straight form there. 